### PR TITLE
feat(validation) add fluent validation for product commands with validation pipeline

### DIFF
--- a/src/FakeStoreNet.Api/Program.cs
+++ b/src/FakeStoreNet.Api/Program.cs
@@ -1,6 +1,13 @@
-
 using FakeStoreNet.Application.Common;
 using FakeStoreNet.Infrastructure.Caching;
+using FluentValidation;
+using FakeStoreNet.Application.Features.Product.Commands.CreateProduct;
+using FakeStoreNet.Application.Features.Product.Commands.UpdateProduct;
+using FakeStoreNet.Application.Features.Product.Commands.DeleteProduct;
+using MediatR;
+using FakeStoreNet.Domain.Exceptions;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Http;
 
 namespace FakeStoreNet.Api
 {
@@ -14,12 +21,42 @@ namespace FakeStoreNet.Api
             builder.Services.AddSingleton<FakeStoreNet.Domain.Common.IEventBus, FakeStoreNet.Infrastructure.EventDispatching.InMemoryEventBus>();
             builder.Services.AddSingleton<FakeStoreNet.Domain.Common.IEventLogRepository, FakeStoreNet.Infrastructure.EventDispatching.InMemoryEventLogRepository>();
 
+            // Register controllers and caching
             builder.Services.AddControllers();
             builder.Services.AddMemoryCache();
             builder.Services.AddSingleton<ICacheService, MemoryCacheService>();
             builder.Services.Configure<CacheSettings>(builder.Configuration.GetSection("CacheSettings"));
 
+            // Register FluentValidation validators
+            builder.Services.AddTransient<IValidator<CreateProductCommand>, CreateProductCommandValidator>();
+            builder.Services.AddTransient<IValidator<UpdateProductCommand>, UpdateProductCommandValidator>();
+            builder.Services.AddTransient<IValidator<DeleteProductCommand>, DeleteProductCommandValidator>();
+
+            // Register validation pipeline behavior
+            builder.Services.AddTransient(typeof(IPipelineBehavior<,>), typeof(ValidationBehavior<,>));
+
             var app = builder.Build();
+
+            // Global exception handling for domain validation errors
+            app.Use(async (context, next) =>
+            {
+                try
+                {
+                    await next();
+                }
+                catch (DomainValidationException ex)
+                {
+                    context.Response.ContentType = "application/problem+json";
+                    context.Response.StatusCode = StatusCodes.Status400BadRequest;
+                    var problem = new ValidationProblemDetails
+                    {
+                        Title = "Validation Failed",
+                        Detail = ex.Message,
+                        Status = StatusCodes.Status400BadRequest
+                    };
+                    await context.Response.WriteAsJsonAsync(problem);
+                }
+            });
 
             // Configure domain event subscriptions
             var eventBus = app.Services.GetRequiredService<FakeStoreNet.Domain.Common.IEventBus>();

--- a/src/FakeStoreNet.Application/Common/ValidationBehavior.cs
+++ b/src/FakeStoreNet.Application/Common/ValidationBehavior.cs
@@ -1,0 +1,54 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentValidation;
+using MediatR;
+using FakeStoreNet.Domain.Exceptions;
+
+namespace FakeStoreNet.Application.Common
+{
+    /// <summary>
+    /// MediatR pipeline behavior for validating requests using FluentValidation.
+    /// Throws a DomainValidationException if any validation failures occur.
+    /// </summary>
+    /// <typeparam name="TRequest">The request type.</typeparam>
+    /// <typeparam name="TResponse">The response type.</typeparam>
+    public class ValidationBehavior<TRequest, TResponse> : IPipelineBehavior<TRequest, TResponse>
+        where TRequest : notnull
+    {
+        private readonly IEnumerable<IValidator<TRequest>> _validators;
+
+        public ValidationBehavior(IEnumerable<IValidator<TRequest>> validators)
+        {
+            _validators = validators;
+        }
+
+        public async Task<TResponse> Handle(
+            TRequest request,
+            RequestHandlerDelegate<TResponse> next,
+            CancellationToken cancellationToken)
+        {
+            if (_validators.Any())
+            {
+                var context = new ValidationContext<TRequest>(request);
+                var validationResults = await Task.WhenAll(
+                    _validators.Select(v => v.ValidateAsync(context, cancellationToken))
+                );
+                var failures = validationResults
+                    .SelectMany(result => result.Errors)
+                    .Where(f => f != null)
+                    .ToList();
+
+                if (failures.Any())
+                {
+                    var messages = failures.Select(f => f.ErrorMessage).ToArray();
+                    var combined = string.Join("; ", messages);
+                    throw new DomainValidationException(combined);
+                }
+            }
+
+            return await next();
+        }
+    }
+}

--- a/src/FakeStoreNet.Application/Features/Product/Commands/DeleteProduct/DeleteProductCommandValidator.cs
+++ b/src/FakeStoreNet.Application/Features/Product/Commands/DeleteProduct/DeleteProductCommandValidator.cs
@@ -1,0 +1,19 @@
+using FluentValidation;
+
+namespace FakeStoreNet.Application.Features.Product.Commands.DeleteProduct
+{
+    /// <summary>
+    /// Validator for <see cref="DeleteProductCommand"/>.
+    /// </summary>
+    public class DeleteProductCommandValidator : AbstractValidator<DeleteProductCommand>
+    {
+        /// <summary>
+        /// Initializes a new instance of <see cref="DeleteProductCommandValidator"/>.
+        /// </summary>
+        public DeleteProductCommandValidator()
+        {
+            RuleFor(x => x.Id)
+                .GreaterThan(0).WithMessage("Id must be greater than zero.");
+        }
+    }
+}

--- a/src/FakeStoreNet.Application/Features/Product/Commands/UpdateProduct/UpdateProductCommandValidator.cs
+++ b/src/FakeStoreNet.Application/Features/Product/Commands/UpdateProduct/UpdateProductCommandValidator.cs
@@ -1,0 +1,43 @@
+using FluentValidation;
+
+namespace FakeStoreNet.Application.Features.Product.Commands.UpdateProduct
+{
+    /// <summary>
+    /// Validator for <see cref="UpdateProductCommand"/>.
+    /// </summary>
+    public class UpdateProductCommandValidator : AbstractValidator<UpdateProductCommand>
+    {
+        /// <summary>
+        /// Initializes a new instance of <see cref="UpdateProductCommandValidator"/>.
+        /// </summary>
+        public UpdateProductCommandValidator()
+        {
+            RuleFor(x => x.Id)
+                .GreaterThan(0).WithMessage("Id must be greater than zero.");
+
+            RuleFor(x => x.Title)
+                .NotEmpty().WithMessage("Title is required.")
+                .MaximumLength(200).WithMessage("Title must not exceed 200 characters.");
+
+            RuleFor(x => x.Description)
+                .NotEmpty().WithMessage("Description is required.");
+
+            RuleFor(x => x.Price)
+                .GreaterThanOrEqualTo(0).WithMessage("Price must be non-negative.");
+
+            RuleFor(x => x.Category)
+                .NotEmpty().WithMessage("Category is required.");
+
+            RuleFor(x => x.Image)
+                .NotEmpty().WithMessage("Image URL is required.")
+                .Must(uri => Uri.IsWellFormedUriString(uri, UriKind.Absolute))
+                .WithMessage("Image must be a valid URL.");
+
+            RuleFor(x => x.Rate)
+                .InclusiveBetween(0.0, 5.0).WithMessage("Rate must be between 0.0 and 5.0.");
+
+            RuleFor(x => x.Count)
+                .GreaterThanOrEqualTo(0).WithMessage("Count must be zero or positive.");
+        }
+    }
+}

--- a/tests/FakeStoreNet.Application.Tests/Features/Product/Commands/CreateProductCommandValidatorTests.cs
+++ b/tests/FakeStoreNet.Application.Tests/Features/Product/Commands/CreateProductCommandValidatorTests.cs
@@ -1,0 +1,51 @@
+using FluentValidation;
+using FakeStoreNet.Application.Features.Product.Commands.CreateProduct;
+using Shouldly;
+using Xunit;
+
+namespace FakeStoreNet.Application.Tests.Features.Product.Commands
+{
+    public class CreateProductCommandValidatorTests
+    {
+        private readonly CreateProductCommandValidator _validator = new CreateProductCommandValidator();
+
+        [Fact(DisplayName = "Given valid create command, validation succeeds")]
+        public void GivenValidCreateCommand_ValidationSucceeds()
+        {
+            var command = new CreateProductCommand
+            {
+                Title = "Valid Title",
+                Description = "Valid Description",
+                Price = 10m,
+                Category = "Category",
+                Image = "http://example.com/image.png",
+                Rate = 4.5,
+                Count = 10
+            };
+
+            var result = _validator.Validate(command);
+
+            result.IsValid.ShouldBeTrue();
+        }
+
+        [Fact(DisplayName = "Given invalid create command, validation fails with expected messages")]
+        public void GivenInvalidCreateCommand_ValidationFails()
+        {
+            var command = new CreateProductCommand
+            {
+                Title = "",
+                Description = "",
+                Price = -5m,
+                Category = "",
+                Image = "not-a-url",
+                Rate = -1.0,
+                Count = -1
+            };
+
+            var result = _validator.Validate(command);
+
+            result.IsValid.ShouldBeFalse();
+            result.Errors.ShouldContain(e => e.ErrorMessage.Contains("required") || e.ErrorMessage.Contains("non-negative") || e.ErrorMessage.Contains("valid URL") || e.ErrorMessage.Contains("between 0.0 and 5.0"));
+        }
+    }
+}

--- a/tests/FakeStoreNet.Application.Tests/Features/Product/Commands/DeleteProductCommandValidatorTests.cs
+++ b/tests/FakeStoreNet.Application.Tests/Features/Product/Commands/DeleteProductCommandValidatorTests.cs
@@ -1,0 +1,37 @@
+using FluentValidation;
+using FakeStoreNet.Application.Features.Product.Commands.DeleteProduct;
+using Shouldly;
+using Xunit;
+
+namespace FakeStoreNet.Application.Tests.Features.Product.Commands
+{
+    public class DeleteProductCommandValidatorTests
+    {
+        private readonly DeleteProductCommandValidator _validator = new DeleteProductCommandValidator();
+
+        [Fact(DisplayName = "Given valid delete command, validation succeeds")]
+        public void GivenValidDeleteCommand_ValidationSucceeds()
+        {
+            var command = new DeleteProductCommand
+            {
+                Id = 1
+            };
+
+            var result = _validator.Validate(command);
+            result.IsValid.ShouldBeTrue();
+        }
+
+        [Fact(DisplayName = "Given invalid delete command, validation fails with expected message")]
+        public void GivenInvalidDeleteCommand_ValidationFails()
+        {
+            var command = new DeleteProductCommand
+            {
+                Id = 0
+            };
+
+            var result = _validator.Validate(command);
+            result.IsValid.ShouldBeFalse();
+            result.Errors.ShouldContain(e => e.ErrorMessage.Contains("greater than zero"));
+        }
+    }
+}

--- a/tests/FakeStoreNet.Application.Tests/Features/Product/Commands/UpdateProductCommandValidatorTests.cs
+++ b/tests/FakeStoreNet.Application.Tests/Features/Product/Commands/UpdateProductCommandValidatorTests.cs
@@ -1,0 +1,55 @@
+using FluentValidation;
+using FakeStoreNet.Application.Features.Product.Commands.UpdateProduct;
+using Shouldly;
+using Xunit;
+
+namespace FakeStoreNet.Application.Tests.Features.Product.Commands
+{
+    public class UpdateProductCommandValidatorTests
+    {
+        private readonly UpdateProductCommandValidator _validator = new UpdateProductCommandValidator();
+
+        [Fact(DisplayName = "Given valid update command, validation succeeds")]
+        public void GivenValidUpdateCommand_ValidationSucceeds()
+        {
+            var command = new UpdateProductCommand
+            {
+                Id = 1,
+                Title = "Valid Title",
+                Description = "Valid Description",
+                Price = 10m,
+                Category = "Category",
+                Image = "http://example.com/image.png",
+                Rate = 4.0,
+                Count = 5
+            };
+
+            var result = _validator.Validate(command);
+            result.IsValid.ShouldBeTrue();
+        }
+
+        [Fact(DisplayName = "Given invalid update command, validation fails with expected messages")]
+        public void GivenInvalidUpdateCommand_ValidationFails()
+        {
+            var command = new UpdateProductCommand
+            {
+                Id = 0,
+                Title = "",
+                Description = "",
+                Price = -1m,
+                Category = "",
+                Image = "not-a-url",
+                Rate = -0.5,
+                Count = -1
+            };
+
+            var result = _validator.Validate(command);
+            result.IsValid.ShouldBeFalse();
+            result.Errors.ShouldContain(e => e.ErrorMessage.Contains("greater than zero"));
+            result.Errors.ShouldContain(e => e.ErrorMessage.Contains("required"));
+            result.Errors.ShouldContain(e => e.ErrorMessage.Contains("non-negative"));
+            result.Errors.ShouldContain(e => e.ErrorMessage.Contains("valid URL"));
+            result.Errors.ShouldContain(e => e.ErrorMessage.Contains("between 0.0 and 5.0"));
+        }
+    }
+}


### PR DESCRIPTION
- Implement CreateProductCommandValidator, UpdateProductCommandValidator, and DeleteProductCommandValidator in application layer
- Add ValidationBehavior<TRequest, TResponse> as a MediatR pipeline to enforce validation
- Register validators and pipeline behavior in Program.cs
- Add global middleware to catch DomainValidationException and return 400 with a ValidationProblemDetails payload
- Introduce unit tests for each product command validator