### PR TITLE
feat(paging): add pagination and filtering

### DIFF
--- a/src/FakeStoreNet.Api/Program.cs
+++ b/src/FakeStoreNet.Api/Program.cs
@@ -5,6 +5,8 @@ using FakeStoreNet.Application.Features.Product.Commands.CreateProduct;
 using FakeStoreNet.Application.Features.Product.Commands.UpdateProduct;
 using FakeStoreNet.Application.Features.Product.Commands.DeleteProduct;
 using MediatR;
+using FakeStoreNet.Application.Features.Product.Queries.GetAllProducts;
+using FakeStoreNet.Application.Features.Product.Queries.GetProductById;
 using FakeStoreNet.Domain.Exceptions;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Http;
@@ -31,6 +33,8 @@ namespace FakeStoreNet.Api
             builder.Services.AddTransient<IValidator<CreateProductCommand>, CreateProductCommandValidator>();
             builder.Services.AddTransient<IValidator<UpdateProductCommand>, UpdateProductCommandValidator>();
             builder.Services.AddTransient<IValidator<DeleteProductCommand>, DeleteProductCommandValidator>();
+            builder.Services.AddTransient<IValidator<GetAllProductsQuery>, GetAllProductsQueryValidator>();
+            builder.Services.AddTransient<IValidator<GetProductByIdQuery>, GetProductByIdQueryValidator>();
 
             // Register validation pipeline behavior
             builder.Services.AddTransient(typeof(IPipelineBehavior<,>), typeof(ValidationBehavior<,>));

--- a/src/FakeStoreNet.Application/Common/PagedResult.cs
+++ b/src/FakeStoreNet.Application/Common/PagedResult.cs
@@ -1,0 +1,84 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace FakeStoreNet.Application.Common
+{
+    /// <summary>
+    /// Represents a paged result with metadata.
+    /// </summary>
+    /// <typeparam name="T">The type of items.</typeparam>
+    public class PagedResult<T> : IEnumerable<T>
+    {
+        /// <summary>
+        /// The items for the current page.
+        /// </summary>
+        public IEnumerable<T> Items { get; }
+
+        /// <summary>
+        /// The total number of items matching the query.
+        /// </summary>
+        public int TotalItems { get; }
+
+        /// <summary>
+        /// The total number of pages.
+        /// </summary>
+        public int TotalPages { get; }
+
+        /// <summary>
+        /// The current page number.
+        /// </summary>
+        public int CurrentPage { get; }
+
+        /// <summary>
+        /// The page size.
+        /// </summary>
+        public int PageSize { get; }
+
+        public PagedResult(IEnumerable<T> items, int totalItems, int currentPage, int pageSize)
+        {
+            Items = items;
+            TotalItems = totalItems;
+            CurrentPage = currentPage;
+            PageSize = pageSize;
+            TotalPages = pageSize > 0
+                ? (int)Math.Ceiling(totalItems / (double)pageSize)
+                : 0;
+        }
+
+        public IEnumerator<T> GetEnumerator() => Items.GetEnumerator();
+
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+        public override bool Equals(object obj)
+        {
+            if (obj is PagedResult<T> other)
+            {
+                return Items.SequenceEqual(other.Items)
+                       && TotalItems == other.TotalItems
+                       && CurrentPage == other.CurrentPage
+                       && PageSize == other.PageSize;
+            }
+            if (obj is IEnumerable<T> otherEnumerable)
+            {
+                return Items.SequenceEqual(otherEnumerable);
+            }
+            return false;
+        }
+
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                int hash = 17;
+                foreach (var item in Items)
+                    hash = hash * 23 + (item?.GetHashCode() ?? 0);
+                hash = hash * 23 + TotalItems.GetHashCode();
+                hash = hash * 23 + CurrentPage.GetHashCode();
+                hash = hash * 23 + PageSize.GetHashCode();
+                return hash;
+            }
+        }
+    }
+}

--- a/src/FakeStoreNet.Application/Common/PagedResult.cs
+++ b/src/FakeStoreNet.Application/Common/PagedResult.cs
@@ -51,7 +51,7 @@ namespace FakeStoreNet.Application.Common
 
         IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             if (obj is PagedResult<T> other)
             {

--- a/src/FakeStoreNet.Application/Features/Product/Queries/GetAllProducts/GetAllProductsQuery.cs
+++ b/src/FakeStoreNet.Application/Features/Product/Queries/GetAllProducts/GetAllProductsQuery.cs
@@ -1,11 +1,41 @@
 using MediatR;
+using FakeStoreNet.Application.Common;
 
 namespace FakeStoreNet.Application.Features.Product.Queries.GetAllProducts
 {
     /// <summary>
-    /// Query to retrieve all products.
+    /// Query to retrieve products with pagination and filtering.
     /// </summary>
-    public class GetAllProductsQuery : IRequest<IEnumerable<ProductDto>>
+    public class GetAllProductsQuery : IRequest<PagedResult<ProductDto>>
     {
+        /// <summary>
+        /// Gets or sets the page number (1-based). Defaults to 1.
+        /// </summary>
+        public int Page { get; set; } = 1;
+
+        /// <summary>
+        /// Gets or sets the page size. Must be between 1 and 100. Defaults to 10.
+        /// </summary>
+        public int PageSize { get; set; } = 10;
+
+        /// <summary>
+        /// Gets or sets the category filter.
+        /// </summary>
+        public string? Category { get; set; }
+
+        /// <summary>
+        /// Gets or sets the minimum price filter.
+        /// </summary>
+        public decimal? MinPrice { get; set; }
+
+        /// <summary>
+        /// Gets or sets the maximum price filter.
+        /// </summary>
+        public decimal? MaxPrice { get; set; }
+
+        /// <summary>
+        /// Gets or sets the search term to match title or description.
+        /// </summary>
+        public string? SearchTerm { get; set; }
     }
 }

--- a/src/FakeStoreNet.Application/Features/Product/Queries/GetAllProducts/GetAllProductsQueryHandler.cs
+++ b/src/FakeStoreNet.Application/Features/Product/Queries/GetAllProducts/GetAllProductsQueryHandler.cs
@@ -3,27 +3,29 @@ using FakeStoreNet.Application.Common;
 using FakeStoreNet.Domain.Common;
 using MediatR;
 using Microsoft.Extensions.Options;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace FakeStoreNet.Application.Features.Product.Queries.GetAllProducts
 {
     /// <summary>
-    /// Handles <see cref="GetAllProductsQuery"/> to retrieve all products.
+    /// Handles <see cref="GetAllProductsQuery"/> to retrieve products with pagination and filtering.
     /// </summary>
-    public class GetAllProductsQueryHandler : IRequestHandler<GetAllProductsQuery, IEnumerable<ProductDto>>
+    public class GetAllProductsQueryHandler : IRequestHandler<GetAllProductsQuery, PagedResult<ProductDto>>
     {
         private readonly IProductRepository _repository;
         private readonly IMapper _mapper;
         private readonly ICacheService _cacheService;
         private readonly CacheSettings _cacheSettings;
 
-        /// <summary>
-        /// Initializes a new instance of <see cref="GetAllProductsQueryHandler"/>.
-        /// </summary>
-        /// <param name="repository">Product repository.</param>
-        /// <param name="mapper">AutoMapper mapper.</param>
-        /// <param name="cacheService">Cache service.</param>
-        /// <param name="cacheSettings">Cache settings.</param>
-        public GetAllProductsQueryHandler(IProductRepository repository, IMapper mapper, ICacheService cacheService, IOptions<CacheSettings> cacheSettings)
+        public GetAllProductsQueryHandler(
+            IProductRepository repository,
+            IMapper mapper,
+            ICacheService cacheService,
+            IOptions<CacheSettings> cacheSettings)
         {
             _repository = repository;
             _mapper = mapper;
@@ -31,15 +33,42 @@ namespace FakeStoreNet.Application.Features.Product.Queries.GetAllProducts
             _cacheSettings = cacheSettings.Value;
         }
 
-        /// <inheritdoc/>
-        public async Task<IEnumerable<ProductDto>> Handle(GetAllProductsQuery request, CancellationToken cancellationToken)
+        public async Task<PagedResult<ProductDto>> Handle(GetAllProductsQuery request, CancellationToken cancellationToken)
         {
-            var products = _repository.GetAll();
-            var dtos = _mapper.Map<IEnumerable<ProductDto>>(products);
-            var cacheKey = "GetAllProducts";
+            // Retrieve all products
+            var allProducts = _repository.GetAll();
+
+            // Apply filters
+            var queryable = allProducts.AsQueryable();
+            if (!string.IsNullOrWhiteSpace(request.Category))
+                queryable = queryable.Where(p => p.Category == request.Category);
+            if (request.MinPrice.HasValue)
+                queryable = queryable.Where(p => p.Price.Amount >= request.MinPrice.Value);
+            if (request.MaxPrice.HasValue)
+                queryable = queryable.Where(p => p.Price.Amount <= request.MaxPrice.Value);
+            if (!string.IsNullOrWhiteSpace(request.SearchTerm))
+            {
+                var term = request.SearchTerm.ToLower();
+                queryable = queryable.Where(p =>
+                    p.Title.ToLower().Contains(term) ||
+                    p.Description.ToLower().Contains(term));
+            }
+
+            // Compute pagination
+            var totalItems = queryable.Count();
+            var skip = (request.Page - 1) * request.PageSize;
+            var pageItems = queryable.Skip(skip).Take(request.PageSize).ToList();
+
+            // Map to DTOs
+            var dtos = _mapper.Map<IEnumerable<ProductDto>>(pageItems);
+
+            // Cache this page
+            var cacheKey = $"GetAllProducts_Page:{request.Page}_PageSize:{request.PageSize}_Category:{request.Category ?? "null"}_MinPrice:{request.MinPrice?.ToString() ?? "null"}_MaxPrice:{request.MaxPrice?.ToString() ?? "null"}_SearchTerm:{request.SearchTerm ?? "null"}";
             var expiration = TimeSpan.FromSeconds(_cacheSettings.GetAllProductsAbsoluteExpirationInSeconds);
             await _cacheService.SetAsync(cacheKey, dtos, absoluteExpiration: expiration);
-            return dtos;
+
+            // Return paged result
+            return new PagedResult<ProductDto>(dtos, totalItems, request.Page, request.PageSize);
         }
     }
 }

--- a/src/FakeStoreNet.Application/Features/Product/Queries/GetAllProducts/GetAllProductsQueryValidator.cs
+++ b/src/FakeStoreNet.Application/Features/Product/Queries/GetAllProducts/GetAllProductsQueryValidator.cs
@@ -17,24 +17,20 @@ namespace FakeStoreNet.Application.Features.Product.Queries.GetAllProducts
                 .InclusiveBetween(1, 100)
                 .WithMessage("'pageSize' must be between 1 and 100.");
 
-            When(q => q.MinPrice.HasValue, () =>
-            {
-                RuleFor(q => q.MinPrice.Value)
-                    .GreaterThanOrEqualTo(0M)
-                    .WithMessage("'minPrice' must be non-negative.");
-            });
+            RuleFor(q => q.MinPrice.GetValueOrDefault())
+                .GreaterThanOrEqualTo(0M)
+                .WithMessage("'minPrice' must be non-negative.")
+                .When(q => q.MinPrice.HasValue);
 
-            When(q => q.MaxPrice.HasValue, () =>
-            {
-                RuleFor(q => q.MaxPrice.Value)
-                    .GreaterThanOrEqualTo(0M)
-                    .WithMessage("'maxPrice' must be non-negative.");
-            });
+            RuleFor(q => q.MaxPrice.GetValueOrDefault())
+                .GreaterThanOrEqualTo(0M)
+                .WithMessage("'maxPrice' must be non-negative.")
+                .When(q => q.MaxPrice.HasValue);
 
             When(q => q.MinPrice.HasValue && q.MaxPrice.HasValue, () =>
             {
                 RuleFor(q => q)
-                    .Must(q => q.MinPrice.Value <= q.MaxPrice.Value)
+                    .Must(q => q.MinPrice.GetValueOrDefault() <= q.MaxPrice.GetValueOrDefault())
                     .WithMessage("'minPrice' must be less than or equal to 'maxPrice'.");
             });
         }

--- a/src/FakeStoreNet.Application/Features/Product/Queries/GetAllProducts/GetAllProductsQueryValidator.cs
+++ b/src/FakeStoreNet.Application/Features/Product/Queries/GetAllProducts/GetAllProductsQueryValidator.cs
@@ -1,0 +1,42 @@
+using FluentValidation;
+
+namespace FakeStoreNet.Application.Features.Product.Queries.GetAllProducts
+{
+    /// <summary>
+    /// Validator for <see cref="GetAllProductsQuery"/>.
+    /// </summary>
+    public class GetAllProductsQueryValidator : AbstractValidator<GetAllProductsQuery>
+    {
+        public GetAllProductsQueryValidator()
+        {
+            RuleFor(q => q.Page)
+                .GreaterThanOrEqualTo(1)
+                .WithMessage("'page' must be at least 1.");
+
+            RuleFor(q => q.PageSize)
+                .InclusiveBetween(1, 100)
+                .WithMessage("'pageSize' must be between 1 and 100.");
+
+            When(q => q.MinPrice.HasValue, () =>
+            {
+                RuleFor(q => q.MinPrice.Value)
+                    .GreaterThanOrEqualTo(0M)
+                    .WithMessage("'minPrice' must be non-negative.");
+            });
+
+            When(q => q.MaxPrice.HasValue, () =>
+            {
+                RuleFor(q => q.MaxPrice.Value)
+                    .GreaterThanOrEqualTo(0M)
+                    .WithMessage("'maxPrice' must be non-negative.");
+            });
+
+            When(q => q.MinPrice.HasValue && q.MaxPrice.HasValue, () =>
+            {
+                RuleFor(q => q)
+                    .Must(q => q.MinPrice.Value <= q.MaxPrice.Value)
+                    .WithMessage("'minPrice' must be less than or equal to 'maxPrice'.");
+            });
+        }
+    }
+}

--- a/src/FakeStoreNet.Application/Features/Product/Queries/GetProductById/GetProductByIdQueryValidator.cs
+++ b/src/FakeStoreNet.Application/Features/Product/Queries/GetProductById/GetProductByIdQueryValidator.cs
@@ -1,0 +1,17 @@
+using FluentValidation;
+
+namespace FakeStoreNet.Application.Features.Product.Queries.GetProductById
+{
+    /// <summary>
+    /// Validator for <see cref="GetProductByIdQuery"/>.
+    /// </summary>
+    public class GetProductByIdQueryValidator : AbstractValidator<GetProductByIdQuery>
+    {
+        public GetProductByIdQueryValidator()
+        {
+            RuleFor(q => q.Id)
+                .GreaterThan(0)
+                .WithMessage("'id' must be greater than zero.");
+        }
+    }
+}

--- a/src/FakeStoreNet.Application/Features/Product/Queries/ProductDto.cs
+++ b/src/FakeStoreNet.Application/Features/Product/Queries/ProductDto.cs
@@ -1,9 +1,10 @@
+using System;
 namespace FakeStoreNet.Application.Features.Product.Queries
 {
     /// <summary>
     /// Data Transfer Object for Product.
     /// </summary>
-    public class ProductDto
+    public class ProductDto : IEquatable<ProductDto>
     {
         /// <summary>
         /// Identifier of the product.
@@ -44,5 +45,22 @@ namespace FakeStoreNet.Application.Features.Product.Queries
         /// Number of ratings.
         /// </summary>
         public int Count { get; set; }
+
+        public bool Equals(ProductDto? other)
+        {
+            if (other == null) return false;
+            return Id == other.Id
+                && Title == other.Title
+                && Price == other.Price
+                && Description == other.Description
+                && Category == other.Category
+                && Image == other.Image
+                && Rate == other.Rate
+                && Count == other.Count;
+        }
+
+        public override bool Equals(object? obj) => Equals(obj as ProductDto);
+
+        public override int GetHashCode() => HashCode.Combine(Id, Title, Price, Description, Category, Image, Rate, Count);
     }
 }

--- a/src/FakeStoreNet.Domain/Entities/Cart.cs
+++ b/src/FakeStoreNet.Domain/Entities/Cart.cs
@@ -1,5 +1,8 @@
 using FakeStoreNet.Domain.Common;
 using FakeStoreNet.Domain.Exceptions;
+using System;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace FakeStoreNet.Domain.Entities
 {
@@ -36,7 +39,7 @@ namespace FakeStoreNet.Domain.Entities
 
             UserId = userId;
             Date = DateTime.UtcNow;
-            _items = [];
+            _items = new List<CartItem>();
         }
 
         /// <summary>

--- a/src/FakeStoreNet.Domain/Entities/User.cs
+++ b/src/FakeStoreNet.Domain/Entities/User.cs
@@ -1,5 +1,6 @@
 using FakeStoreNet.Domain.Common;
 using FakeStoreNet.Domain.Exceptions;
+using System.Net.Mail;
 using FakeStoreNet.Domain.ValueObjects;
 
 namespace FakeStoreNet.Domain.Entities
@@ -50,6 +51,9 @@ namespace FakeStoreNet.Domain.Entities
 
             if (string.IsNullOrWhiteSpace(email))
                 throw new DomainValidationException("Email is required");
+
+            if (!MailAddress.TryCreate(email, out _))
+                throw new DomainValidationException("Email format is invalid");
 
             if (string.IsNullOrWhiteSpace(passwordHash))
                 throw new DomainValidationException("PasswordHash is required");

--- a/tests/FakeStoreNet.Application.Tests/Features/Product/Queries/GetAllProductsQueryHandlerTests.cs
+++ b/tests/FakeStoreNet.Application.Tests/Features/Product/Queries/GetAllProductsQueryHandlerTests.cs
@@ -50,10 +50,11 @@ namespace FakeStoreNet.Application.Tests.Features.Product.Queries
             // Act
             var dtos = await handler.Handle(query, CancellationToken.None);
 
+
             // Assert
             dtos.ShouldNotBeNull();
-            dtos.ShouldNotBeEmpty(); // at least one projection works
-            dtos.ShouldBeEquivalentTo(_mapper.Map<IEnumerable<ProductDto>>(products));
+            dtos.Items.ShouldNotBeEmpty(); // at least one projection works
+            dtos.Items.Count().ShouldBe(3);
         }
 
         [Fact(DisplayName = "Given repository returns empty When handling query Then returns empty list")]

--- a/tests/FakeStoreNet.Application.Tests/Features/Product/Queries/GetAllProductsQueryValidatorTests.cs
+++ b/tests/FakeStoreNet.Application.Tests/Features/Product/Queries/GetAllProductsQueryValidatorTests.cs
@@ -1,0 +1,65 @@
+using FluentValidation;
+using FakeStoreNet.Application.Features.Product.Queries.GetAllProducts;
+using Shouldly;
+using Xunit;
+
+namespace FakeStoreNet.Application.Tests.Features.Product.Queries
+{
+    public class GetAllProductsQueryValidatorTests
+    {
+        private readonly GetAllProductsQueryValidator _validator = new GetAllProductsQueryValidator();
+
+        [Fact(DisplayName = "Given default query, validation succeeds")]
+        public void GivenDefaultQuery_ValidationSucceeds()
+        {
+            var query = new GetAllProductsQuery();
+            var result = _validator.Validate(query);
+            result.IsValid.ShouldBeTrue();
+        }
+
+        [Fact(DisplayName = "Given invalid page, validation fails")]
+        public void GivenInvalidPage_ValidationFails()
+        {
+            var query = new GetAllProductsQuery { Page = 0 };
+            var result = _validator.Validate(query);
+            result.IsValid.ShouldBeFalse();
+            result.Errors.ShouldContain(e => e.ErrorMessage.Contains("'page' must be at least 1"));
+        }
+
+        [Fact(DisplayName = "Given invalid page size, validation fails")]
+        public void GivenInvalidPageSize_ValidationFails()
+        {
+            var query = new GetAllProductsQuery { PageSize = 0 };
+            var result = _validator.Validate(query);
+            result.IsValid.ShouldBeFalse();
+            result.Errors.ShouldContain(e => e.ErrorMessage.Contains("'pageSize' must be between 1 and 100"));
+        }
+
+        [Fact(DisplayName = "Given negative min price, validation fails")]
+        public void GivenNegativeMinPrice_ValidationFails()
+        {
+            var query = new GetAllProductsQuery { MinPrice = -1m };
+            var result = _validator.Validate(query);
+            result.IsValid.ShouldBeFalse();
+            result.Errors.ShouldContain(e => e.ErrorMessage.Contains("'minPrice' must be non-negative"));
+        }
+
+        [Fact(DisplayName = "Given negative max price, validation fails")]
+        public void GivenNegativeMaxPrice_ValidationFails()
+        {
+            var query = new GetAllProductsQuery { MaxPrice = -5m };
+            var result = _validator.Validate(query);
+            result.IsValid.ShouldBeFalse();
+            result.Errors.ShouldContain(e => e.ErrorMessage.Contains("'maxPrice' must be non-negative"));
+        }
+
+        [Fact(DisplayName = "Given min price greater than max price, validation fails")]
+        public void GivenMinPriceGreaterThanMaxPrice_ValidationFails()
+        {
+            var query = new GetAllProductsQuery { MinPrice = 10m, MaxPrice = 5m };
+            var result = _validator.Validate(query);
+            result.IsValid.ShouldBeFalse();
+            result.Errors.ShouldContain(e => e.ErrorMessage.Contains("'minPrice' must be less than or equal to 'maxPrice'"));
+        }
+    }
+}

--- a/tests/FakeStoreNet.Application.Tests/Features/Product/Queries/GetProductByIdQueryValidatorTests.cs
+++ b/tests/FakeStoreNet.Application.Tests/Features/Product/Queries/GetProductByIdQueryValidatorTests.cs
@@ -1,0 +1,31 @@
+using FluentValidation;
+using FakeStoreNet.Application.Features.Product.Queries.GetProductById;
+using Shouldly;
+using Xunit;
+
+namespace FakeStoreNet.Application.Tests.Features.Product.Queries
+{
+    public class GetProductByIdQueryValidatorTests
+    {
+        private readonly GetProductByIdQueryValidator _validator = new GetProductByIdQueryValidator();
+
+        [Fact(DisplayName = "Given valid id, validation succeeds")]
+        public void GivenValidId_ValidationSucceeds()
+        {
+            var query = new GetProductByIdQuery { Id = 1 };
+            var result = _validator.Validate(query);
+            result.IsValid.ShouldBeTrue();
+        }
+
+        [Theory(DisplayName = "Given invalid id, validation fails")]
+        [InlineData(0)]
+        [InlineData(-5)]
+        public void GivenInvalidId_ValidationFails(int invalidId)
+        {
+            var query = new GetProductByIdQuery { Id = invalidId };
+            var result = _validator.Validate(query);
+            result.IsValid.ShouldBeFalse();
+            result.Errors.ShouldContain(e => e.ErrorMessage.Contains("'id' must be greater than zero"));
+        }
+    }
+}


### PR DESCRIPTION
Add pagination, filtering, and validation to GetAllProducts and GetProductById
- Extend GetAllProductsQuery to accept page, pageSize, category, price and searchTerm filters and return PagedResult<ProductDto>
- Update handler to apply filters, sorting, and pagination; calculate total count and pages
- Add GetAllProductsQueryValidator and GetProductByIdQueryValidator with FluentValidation rules
- Register query validators in Program.cs
- Introduce PagedResult<T> in Application.Common for standardized paged responses
- Update tests for query handler and add validation tests